### PR TITLE
Fix undefined array key "action"

### DIFF
--- a/cleverpush.php
+++ b/cleverpush.php
@@ -757,7 +757,7 @@ if ( ! class_exists( 'CleverPush' ) ) :
 		}
 
 		public function publish_post($post_id) {
-			if ('inline-save' == $_POST['action']) {
+			if (isset($_POST['action']) && 'inline-save' == $_POST['action']) {
 				return;
 			}
 


### PR DESCRIPTION
This PR should fix the following PHP Warning.
`PHP message: PHP Warning: Undefined array key "action" in /var/www/htdocs/content/plugins/cleverpush/cleverpush.php on line 760`